### PR TITLE
tools: Add tool for sdcard layout generation

### DIFF
--- a/gensdimg.sh
+++ b/gensdimg.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+
+SDIMG=generated/sdcard.img
+
+PART_START=$(( 2048 * 1024 ))
+ALIGN=1048576
+
+PTR=$PART_START
+GPT_SIZE=$(( 512 * 34 ))
+pn=1
+
+add_part() {
+	SIZE=$(stat $1 -c%s)
+	# Align size
+	SIZE="$(( ($SIZE / $ALIGN + 1) * $ALIGN))"
+	echo $1: size=$SIZE
+	echo $1: partition offset=$PTR
+
+	dd if=/dev/null of=$SDIMG bs=1 count=1 seek=$(( $PTR + $SIZE + $GPT_SIZE ))
+
+	sgdisk -e $SDIMG
+
+	sgdisk -n $pn:$(( PTR / 512 )):$(( ($PTR + $SIZE - 1) / 512 )) -c=$pn:"$2" ${SDIMG}
+
+	dd if=$1 of=$SDIMG bs=4096 count=$(( SIZE/4096 )) seek=$(( $PTR / 4096 )) conv=notrunc && sync
+
+	PTR=$(( $PTR + $SIZE ))
+	pn=$(( $pn+1 ))
+}
+
+# Create raw disk image
+dd if=/dev/zero of=${SDIMG} bs=4096 count=$(( (PART_START + GPT_SIZE * 2) / 4096 ))
+sgdisk -Z ${SDIMG}
+
+# Reduce GPT to have 56 partitions max (LBA 2-15, u-boot is located starting from LBA 16)
+gdisk ${SDIMG}<<EOF
+x
+s
+56
+w
+Y
+EOF
+
+# Compiling boot script
+mkimage -A arm -O linux -T script -C none -a 0 -e 0 -d boot.txt generated/boot.scr
+
+# Create boot.img
+rm generated/boot.img
+mkfs.vfat -n "orange-pi" -S 512 -C generated/boot.img $(( 1024 * 10 ))
+mcopy -i generated/boot.img -s uImage ::uImage
+mcopy -i generated/boot.img -s generated/boot.scr ::boot.scr
+mcopy -i generated/boot.img -s sun8i-h3-orangepi-one.dtb ::sun8i-h3-orangepi-one.dtb
+
+# Add partitions
+add_part generated/boot.img boot
+add_part vendor.img vendor
+add_part system.img system
+add_part vbmeta.img vbmeta
+add_part userdata.img userdata
+
+# Put u-boot with spl to image
+dd if=u-boot-sunxi-with-spl.bin of=${SDIMG} bs=1024 seek=8 conv=notrunc


### PR DESCRIPTION
This version of tool requires the following files to be in the same directory:

boot.txt - boot script for u-boot
u-boot-sunxi-with-spl.bin - u-boot binary with spl
uImage - Kernel image in the u-boot wrapper

Images from android output folder:
system.img vendor.img vbmeta.img userdata.img

Successfully tested on the orange-pi one board

Signed-off-by: Roman Stratiienko <roman.stratiienko@globallogic.com>