### PR TITLE
Add configuration for dtb image building

### DIFF
--- a/kernel/kernel.mk
+++ b/kernel/kernel.mk
@@ -18,7 +18,7 @@ KERNEL_BOOT_DIR		:= arch/$(TARGET_ARCH)/boot
 DTB_IMG			:= $(PRODUCT_OUT)/dtb.img
 KERNEL_DTS_DIR		:= $(KERNEL_BOOT_DIR)/dts
 KERNEL_DTB_OUT		:= $(KERNEL_OUT)/$(KERNEL_DTS_DIR)
-DTB_IMG_CONFIG		:= $(KERNEL_SRC)/$(KERNEL_DTS_DIR)/sun8i-h3-orangepi-plus2e.dts
+DTB_IMG_CONFIG		:= $(KERNEL_SRC)/$(KERNEL_DTS_DIR)/sunxi.dtbimg.cfg
 
 #-------------------------------------------------------------------------------
 ifeq ($(KERNEL_CROSS_COMPILE),)


### PR DESCRIPTION
I hope this pr fix a issue dtb-image build:

/bin/bash: mkdtimg: command not found